### PR TITLE
Moving html/ in gh_pages branch to API/

### DIFF
--- a/CYCAMORE/gh_pages.sh
+++ b/CYCAMORE/gh_pages.sh
@@ -8,7 +8,7 @@ ls -l
 
 cd cyclus
 git checkout gh-pages
-rsync -a ../cyclusdoc/html* .
+rsync -a ../cycamoredoc/html/* API/
 git add -A
 git commit -m "nightly build"
 git push -f ssh://git@github.com/cyclus/cyclus.git gh-pages
@@ -17,7 +17,7 @@ cd ..
 
 cd cycamore
 git checkout gh-pages
-rsync -a ../cycamoredoc/html* .
+rsync -a ../cycamoredoc/html/* API/
 git add -A
 git commit -m "nightly build"
 git push -f ssh://git@github.com/cyclus/cycamore.git gh-pages


### PR DESCRIPTION
Per @gonuke's request.  We also probably need to go into cyclus and cycamore and delete the html dir that's currently in their gh_pages branch
