### PR TITLE
fixes issue when no changes

### DIFF
--- a/CYCAMORE/gh_pages.sh
+++ b/CYCAMORE/gh_pages.sh
@@ -12,16 +12,19 @@ tar -xzf results.tar.gz
 cd cyclus
 git checkout gh-pages
 rsync -a ../cyclusdoc/html/* api/
+if [ -n "$(git status --porcelain)" ]; then 
 git add -A
 git commit -m "nightly build"
 git push -f ssh://git@github.com/cyclus/cyclus.git gh-pages
+fi
 cd ..
 
 
 cd cycamore
 git checkout gh-pages
 rsync -a ../cycamoredoc/html/* api/
+if [ -n "$(git status --porcelain)" ]; then 
 git add -A
 git commit -m "nightly build"
 git push -f ssh://git@github.com/cyclus/cycamore.git gh-pages
-
+fi


### PR DESCRIPTION
Yay corner cases. 

See http://submit-1.batlab.org/nmi/results/details?runID=213186 which skips Cyclus with no changes but pushes doc to cycamore.
