### PR TITLE
Attempt to fix doc-based repo growth

### DIFF
--- a/CYCAMORE/gh_pages.sh
+++ b/CYCAMORE/gh_pages.sh
@@ -15,7 +15,7 @@ git checkout develop
 git branch -D gh-pages
 git checkout -b  gh-pages
 
-git rm -r *
+git rm -r * .gitignore
 
 git reflog expire --expire-unreachable=now --all
 git gc --prune
@@ -33,7 +33,7 @@ git checkout develop
 git branch -D gh-pages
 git checkout -b  gh-pages
 
-git rm -r *
+git rm -r * .gitignore
 
 git reflog expire --expire-unreachable=now --all
 git gc --prune


### PR DESCRIPTION
Kills gh-pages branch, garbage collects branch less commits, and recreates gh-pages. Shrinks cyclus from 40mb to 10mb. See my cyclus and cycamore forks  and http://submit-1.batlab.org/nmi/results/details?runID=226639
