### PR TITLE
Fixes boost build error

### DIFF
--- a/cycamore.fast.run-spec
+++ b/cycamore.fast.run-spec
@@ -4,7 +4,6 @@ x86_64_MacOSX8_remote_pre_declare = CYCAMORE/build.mac.sh
 x86_64_Ubuntu12_remote_pre_declare = CYCAMORE/build.sh
 remote_task = CYCAMORE/run_test.fast.sh
 x86_64_Ubuntu12_remote_post = CYCAMORE/build_doc.sh
-platform_post = CYCAMORE/gh_pages.sh
 platforms   = x86_64_Ubuntu12,x86_64_MacOSX8
 project     = <a href="http://fuelcycle.org">Cyclus</a>
 project_version = fast_dev/dev

--- a/fetch/myCiclus.scp
+++ b/fetch/myCiclus.scp
@@ -1,5 +1,5 @@
 
 method    = scp
-scp_file  = /home/zach.welch/ciclus/*
+scp_file  = /home/cyclusci/ciclus/*
 recursive = true
 


### PR DESCRIPTION
Fixes this error on Ubuntu (http://submit-1.batlab.org/nmi/results/details?runID=238888). I suspect batlab updated cmake, screwing up our boost search.  This change forces cmake to use the custom boost install.  The current version of cyclus hangs like on Mac OSX when this is fixed, so I used the last passing pull request (779) http://submit-1.batlab.org/nmi/results/details?runID=239111.  Without this change, 779 also fails, which makes me think this is a batlab change.
