### PR TITLE
CI Fix

### DIFF
--- a/fetch/cython.git
+++ b/fetch/cython.git
@@ -1,2 +1,4 @@
 method = git
 git_repo = https://github.com/cython/cython.git
+git_path = cython;cd cython;git checkout tags/0.20.1
+


### PR DESCRIPTION
I fixed cython to build tag 0.20.1 rather than HEAD.  This is a temporary fix, and a more comprehensive PR  that moves the regression test dependencies into fast/nightly deps should be coming later this week.

Before: http://submit-1.batlab.org/nmi/results/details?runID=254453
After   : http://submit-1.batlab.org/nmi/results/details?runID=254458
