### PR TITLE
automatic pushes of nightly conda packaes to binstar

### DIFF
--- a/CYCA/build.sh
+++ b/CYCA/build.sh
@@ -4,9 +4,22 @@ set -e
 
 `pwd`/CYCL/build.sh
 PATH=$PATH:`pwd`/install/bin
+anaconda/bin/conda list
+#force cycamore to build with local cyclus
+vers=`anaconda/bin/conda list | grep cyclus`
+read -a versArray <<< $vers
+if [[  `uname` == 'Linux' ]]; then
+sed -i  "s/- cyclus/- cyclus ${versArray[1]}/g" cycamore/meta.yaml
+else
+sed -i '' "s/- cyclus/- cyclus ${versArray[1]}/g" cycamore/meta.yaml
+fi
 
-anaconda/bin/conda build --no-test cycamore
-anaconda/bin/conda install --use-local cycamore
+#force cycamore to build with local cyclus
+vers=`cat cycamore/meta.yaml | grep version`
+read -a versArray <<< $vers
+
+anaconda/bin/conda build --no-test cycamore 
+anaconda/bin/conda install --use-local cycamore=${versArray[1]}
 
 cp -r anaconda/conda-bld/work/tests cycatest
 

--- a/CYCA/gh_pages.sh
+++ b/CYCA/gh_pages.sh
@@ -4,6 +4,17 @@ set -e
 
 tar -xzf results.tar.gz
 
+if [ -d "anaconda/conda-bld/linux-64" ]; then
+os=linux-64
+else
+os=osx-64
+fi
+
+for f in `ls anaconda/conda-bld/$os/*tar.bz2`;do
+     echo $f
+    /home/$USER/miniconda/bin/binstar upload -u cyclus --force $f
+done
+
 if [[ ! -d cycamoredoc ]] 
 then
 exit 0

--- a/CYCL/build.sh
+++ b/CYCL/build.sh
@@ -41,7 +41,12 @@ fi
 anaconda/bin/conda install jinja2
 anaconda/bin/conda install setuptools
 anaconda/bin/conda build --no-test cyclus
-anaconda/bin/conda install --use-local cyclus
+
+#force cycamore to build with local cyclus
+vers=`cat cyclus/meta.yaml | grep version`
+read -a versArray <<< $vers
+
+anaconda/bin/conda install --use-local cyclus=${versArray[1]}
 tar -czf results.tar.gz anaconda
 
 cp -r anaconda/conda-bld/work/tests cycltest

--- a/cycamore/meta.yaml
+++ b/cycamore/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: cycamore
-  version: 1.0
+  version: 0.0
 
 source:
 #  fn: develop.zip
@@ -17,7 +17,7 @@ requirements:
 
 build:
   number: 3
-
+  string: nightly
 about:
   home: Cyclus
   license: BSD 3 Clause

--- a/cyclus/meta.yaml
+++ b/cyclus/meta.yaml
@@ -1,6 +1,6 @@
 package:
   name: cyclus
-  version: 1.0
+  version: 0.0
 
 source:
   #fn: develop.zip # [linux]
@@ -39,7 +39,7 @@ requirements:
 
 build:
   number: 2
-
+  string: nightly
 about:
   home: Cyclus
   license: BSD Clause 3


### PR DESCRIPTION
Right now this is configured to push the nightly build package, but it shouldn't be hard to convert to polyphemus-built packages if that's what we decide to do...  Because of conda install versioning and not wanting the nightly build to be what is automatically downloaded, the nightly build has a "0.0" version.
