### PR TITLE
changes fast run specs to use myCiclus

### DIFF
--- a/cycamore.fast.run-spec
+++ b/cycamore.fast.run-spec
@@ -1,5 +1,5 @@
 run_type    = test
-inputs      = fetch/conda.linux.url,fetch/conda.mac.url, fetch/git.git, fetch/conda.scp,fetch/conda-recipe.git
+inputs      = fetch/conda.linux.url,fetch/conda.mac.url, fetch/git.git, fetch/myCiclus.scp,fetch/conda-recipe.git
 remote_pre_declare = CYCA/build.sh
 remote_task = CYCA/run_test.sh
 platforms   = x86_64_Ubuntu12,x86_64_MacOSX8

--- a/cyclus.fast.run-spec
+++ b/cyclus.fast.run-spec
@@ -1,5 +1,5 @@
 run_type    = test
-inputs      = fetch/conda.linux.url,fetch/conda.mac.url, fetch/git.git, fetch/conda.scp
+inputs      = fetch/conda.linux.url,fetch/conda.mac.url, fetch/git.git, fetch/myCiclus.scp
 remote_pre_declare = CYCL/build.sh
 remote_task = CYCL/run_test.sh
 platforms   = x86_64_MacOSX8,x86_64_Ubuntu12


### PR DESCRIPTION
This is a fix for the fast builds used with polyphemus that are currently broken.  [Here is a working example.](http://submit-1.batlab.org/nmi/results/details?groupBy=platform&runID=279264&groupDirection=down&sortDirection=down&sortBy=taskID&refreshTime=20) This issue is currently blocking all cyclus and cycamore PRs.
