### PR TITLE
Meta.yaml

### DIFF
--- a/cycamore/meta.yaml
+++ b/cycamore/meta.yaml
@@ -2,11 +2,10 @@ package:
   name: cycamore
   version: 0.0
 
+# Only use fn and url for polyphemus compatability
 source:
-  fn: develop.zip # [linux and __import__('os').getenv('NMI_PLATFORM')]
-  url: https://github.com/cyclus/cycamore/archive/develop.zip # [linux and __import__('os').getenv('NMI_PLATFORM')]
-  git_url: https://github.com/cyclus/cycamore.git # [not (linux and __import__('os').getenv('NMI_PLATFORM'))]
-  git_tag: develop # [not (linux and __import__('os').getenv('NMI_PLATFORM'))]
+  fn: cycamore-src.tar.gz
+  url: https://github.com/cyclus/cycamore/archive/develop.tar.gz
 
 requirements:
    build:

--- a/cyclus/meta.yaml
+++ b/cyclus/meta.yaml
@@ -3,10 +3,10 @@ package:
   version: 0.0
 
 source:
-  fn: develop.tar.gz # [linux and __import__('os').getenv('NMI_PLATFORM')]
-  url: https://github.com/cyclus/cyclus/archive/develop.tar.gz # [linux and __import__('os').getenv('NMI_PLATFORM')]
-  git_url: https://github.com/cyclus/cyclus.git # [not (linux and __import__('os').getenv('NMI_PLATFORM'))]
-  git_tag: develop # [not (linux and __import__('os').getenv('NMI_PLATFORM'))]
+  fn: develop.tar.gz # [linux and environ.get('NMI_PLATFORM', False)]
+  url: https://github.com/cyclus/cyclus/archive/develop.tar.gz # [linux and environ.get('NMI_PLATFORM', False)]
+  git_url: https://github.com/cyclus/cyclus.git # [not (linux and environ.get('NMI_PLATFORM', False))]
+  git_tag: develop # [not (linux and environ.get('NMI_PLATFORM', False))]
 
 requirements:
    build:

--- a/cyclus/meta.yaml
+++ b/cyclus/meta.yaml
@@ -2,6 +2,7 @@ package:
   name: cyclus
   version: 0.0
 
+# Only use fn and url for polyphemus compatability
 source:
   fn: cyclus-src.tar.gz 
   url: https://github.com/cyclus/cyclus/archive/develop.tar.gz 

--- a/cyclus/meta.yaml
+++ b/cyclus/meta.yaml
@@ -3,10 +3,8 @@ package:
   version: 0.0
 
 source:
-  fn: develop.tar.gz # [linux and environ.get('NMI_PLATFORM', False)]
-  url: https://github.com/cyclus/cyclus/archive/develop.tar.gz # [linux and environ.get('NMI_PLATFORM', False)]
-  git_url: https://github.com/cyclus/cyclus.git # [not (linux and environ.get('NMI_PLATFORM', False))]
-  git_tag: develop # [not (linux and environ.get('NMI_PLATFORM', False))]
+  fn: cyclus-src.tar.gz 
+  url: https://github.com/cyclus/cyclus/archive/develop.tar.gz 
 
 requirements:
    build:

--- a/cymetric/meta.yaml
+++ b/cymetric/meta.yaml
@@ -2,11 +2,10 @@ package:
   name: cymetric
   version: 0.0
 
+# Only use fn and url for polyphemus compatability
 source:
-  fn: master.zip # [__import__('os').getenv('NMI_PLATFORM')]
-  url: https://github.com/cyclus/cymetric/archive/master.zip # [__import__('os').getenv('NMI_PLATFORM')]
-  git_url: https://github.com/cyclus/cymetric.git # [not __import__('os').getenv('NMI_PLATFORM')]
-  git_tag: master # [not __import__('os').getenv('NMI_PLATFORM')]
+  fn: cymetric-src.tar.gz
+  url: https://github.com/cyclus/cymetric/archive/master.tar.gz
 
 requirements:
    build:


### PR DESCRIPTION
These updates to the meta.yaml files should allow for cyclus-ci to work with the most recent polyphemus. A successful run may be seen here: http://submit-1.batlab.org/nmi/results/details?groupBy=platform&runID=307762&groupDirection=down&sortDirection=down&sortBy=taskID