### PR TITLE
Another fix for finding the workdir

### DIFF
--- a/CYCA/build.sh
+++ b/CYCA/build.sh
@@ -5,7 +5,7 @@ set -e
 `pwd`/CYCL/build.sh
 PATH=$PATH:`pwd`/install/bin
 UNAME=$(uname)
-cycamore_tar_dir="cycamore-develop"
+proj="cycamore"
 anaconda/bin/conda list
 
 # force cycamore to build with local cyclus
@@ -25,8 +25,8 @@ anaconda/bin/conda build --no-test cycamore
 anaconda/bin/conda install --use-local cycamore=${versArray[1]}
 
 # Setup workdir for later use
-if [ -d "anaconda/conda-bld/work/${cycamore_tar_dir}" ]; then
-  export WORKDIR="anaconda/conda-bld/work/${cycamore_tar_dir}"
+if [ -d "$(ls -d anaconda/conda-bld/work/*${proj}*/tests)" ]; then
+  export WORKDIR="$(ls -d anaconda/conda-bld/work/*${proj}*)"
 else  
   export WORKDIR="anaconda/conda-bld/work"
 fi

--- a/CYCL/build.sh
+++ b/CYCL/build.sh
@@ -5,14 +5,14 @@ set -e
 ./bin/conda-inst.sh
 export PATH="$(pwd)/anaconda/bin:${PATH}"
 UNAME=$(uname)
-cyclus_tar_dir="cyclus-develop"
+proj="cyclus"
 
 # Build Cyclus, must happen before we set the workdir
 anaconda/bin/conda build --no-test cyclus
 
 # Setup workdir for later use
-if [ -d "anaconda/conda-bld/work/${cyclus_tar_dir}" ]; then
-  export WORKDIR="anaconda/conda-bld/work/${cyclus_tar_dir}"
+if [ -d "$(ls -d anaconda/conda-bld/work/*${proj}*/tests)" ]; then
+  export WORKDIR="$(ls -d anaconda/conda-bld/work/*${proj}*)"
 else  
   export WORKDIR="anaconda/conda-bld/work"
 fi

--- a/CYM/build.sh
+++ b/CYM/build.sh
@@ -5,7 +5,7 @@ set -e
 ./bin/conda-inst.sh
 export PATH="$(pwd)/anaconda/bin:${PATH}"
 UNAME=$(uname)
-cymetric_tar_dir="cymetric-master"
+proj="cymetric"
 
 # Build Cyclus, must happen before we set the workdir
 anaconda/bin/conda install cyclus cycamore
@@ -21,8 +21,8 @@ cyclus --version
 anaconda/bin/conda build --no-test cymetric
 
 # Setup workdir for later use
-if [ -d "anaconda/conda-bld/work/${cymetric_tar_dir}" ]; then
-  export WORKDIR="anaconda/conda-bld/work/${cymetric_tar_dir}"
+if [ -d "$(ls -d anaconda/conda-bld/work/*${proj}*/tests)" ]; then
+  export WORKDIR="$(ls -d anaconda/conda-bld/work/*${proj}*)"
 else  
   export WORKDIR="anaconda/conda-bld/work"
 fi


### PR DESCRIPTION
This addresses an issue where the wrong workdir is being computed in the event of a PR.  This does a more robust job of computing the workdir path with globs.  

Here is an example in action: http://submit-1.batlab.org/nmi/results/details?groupBy=platform&runID=307886&groupDirection=down&sortBy=taskID&sortDirection=down  Note that this is based on cyclus/cyclus#1100 and so is supposed to fail. It does fail and in the proper way.